### PR TITLE
NewNamedType()

### DIFF
--- a/egoist/generators/structkit/_context.py
+++ b/egoist/generators/structkit/_context.py
@@ -80,7 +80,7 @@ class Context:
         ]
 
         pseudo_item = Item(
-            name=item.type_.__name__,  # fixme
+            name=item.name,
             type_=item.type_,
             fields=[discriminator_field] + pseudo_fields,
             args=[],

--- a/egoist/generators/structkit/_emit.py
+++ b/egoist/generators/structkit/_emit.py
@@ -70,7 +70,7 @@ def emit_union(ctx: Context, item: Item) -> runtime.Definition:
     m = ctx.m
     resolver = ctx.resolver
 
-    typename = goname(item.type_.__name__)
+    typename = goname(item.name)
     kind_typename = typename + "Kind"
 
     # type <typename> {
@@ -95,7 +95,7 @@ def emit_union(ctx: Context, item: Item) -> runtime.Definition:
 
     # one-of validation
     assert unmarshalJSON_definition.code_module is not None
-    this = m.symbol(f"{item.type_.__name__[0].lower()}")
+    this = m.symbol(f"{item.name[0].lower()}")
     maperr_pkg = m.import_("github.com/podhmo/maperr")
 
     sm = unmarshalJSON_definition.code_module
@@ -180,7 +180,7 @@ def emit_unmarshalJSON(ctx: Context, item: Item) -> runtime.Definition:
     m = ctx.m
     resolver = ctx.resolver
 
-    this = m.symbol(f"{item.type_.__name__[0].lower()}")
+    this = m.symbol(f"{item.name[0].lower()}")
     this_type = f"{resolver.resolve_gotype(item.type_)}"
     this_type_pointer = f"*{this_type}"
 

--- a/egoist/generators/structkit/_walk.py
+++ b/egoist/generators/structkit/_walk.py
@@ -3,6 +3,7 @@ import typing as t
 from functools import lru_cache
 from metashape.declarative import MISSING
 from metashape.types import Kind as NodeKind
+from egoist.typing import resolve_name, guess_name
 from . import runtime
 from ._context import Context, Item
 
@@ -24,14 +25,18 @@ def walk(
             args = list(t.get_args(cls))
             if origin == t.Union and _nonetype not in args:  # union
                 yield Item(
-                    name="<union>", type_=cls, fields=[], args=args, origin=origin
+                    name=guess_name(cls), type_=cls, fields=[], args=args, origin=origin
                 )  # fixme
                 for subtype in get_flatten_args(cls):
                     w.append(subtype)
                 continue
             elif origin == t.Literal:  # literal
                 yield Item(
-                    name="<literal>", type_=cls, fields=[], args=args, origin=origin
+                    name=resolve_name(cls),
+                    type_=cls,
+                    fields=[],
+                    args=args,
+                    origin=origin,
                 )  # fixme name
                 continue
             else:
@@ -58,7 +63,7 @@ def walk(
             for subtype in get_flatten_args(info.type_):
                 w.append(subtype)
 
-        yield Item(name=cls.__name__, type_=cls, fields=fields, args=[])
+        yield Item(name=resolve_name(cls), type_=cls, fields=fields, args=[])
 
 
 @lru_cache(maxsize=256)

--- a/egoist/generators/structkit/_walk.py
+++ b/egoist/generators/structkit/_walk.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import typing as t
 from functools import lru_cache
 from metashape.declarative import MISSING
+from metashape.types import Kind as NodeKind
 from . import runtime
 from ._context import Context, Item
 
@@ -11,11 +12,13 @@ def walk(
     classes: t.List[t.Type[t.Any]],
     *,
     _nonetype: t.Type[t.Any] = type(None),
+    kinds: t.Optional[t.List[t.Optional[NodeKind]]] = None,
 ) -> t.Iterator[Item]:
     metadata_handler = ctx.metadata_handler
-
     w = ctx.get_metashape_walker(classes)
-    for cls in w.walk(kinds=["object", None]):
+
+    kinds = kinds or ["object", None, "enum"]
+    for cls in w.walk(kinds=kinds):
         origin = getattr(cls, "__origin__", None)
         if origin is not None:
             args = list(t.get_args(cls))

--- a/egoist/go/resolver.py
+++ b/egoist/go/resolver.py
@@ -4,8 +4,8 @@ from egoist import types
 from prestring.utils import UnRepr
 from prestring.go import goname
 from prestring.go.codeobject import Module
+from egoist.typing import resolve_name_maybe
 from .types import GoPointer, get_gopackage
-from metashape.name import resolve_maybe as resolve_name_maybe
 
 
 class Resolver:

--- a/egoist/go/resolver.py
+++ b/egoist/go/resolver.py
@@ -5,6 +5,7 @@ from prestring.utils import UnRepr
 from prestring.go import goname
 from prestring.go.codeobject import Module
 from .types import GoPointer, get_gopackage
+from metashape.name import resolve_maybe as resolve_name_maybe
 
 
 class Resolver:
@@ -39,9 +40,10 @@ class Resolver:
             ):
                 v = self.resolve_gotype(args[0])
                 return f"*{v}"
-            elif hasattr(typ, "__name__"):
-                return typ.__name__  # TODO: prefix
             else:
+                name = resolve_name_maybe(typ)
+                if name is not None:
+                    return name
                 raise RuntimeError(f"unexpected origin {origin!r}")
 
         gotype = self.gotype_map.get(typ)
@@ -54,7 +56,9 @@ class Resolver:
             prefix = f"{self.m.import_(pkg)}."
 
         py_clsname = getattr(typ, "__qualname__", typ.__name__)
-        if "<locals>" in py_clsname:  # HACK: for the type defined in closure. (e.g. t.NewType)
+        if (
+            "<locals>" in py_clsname
+        ):  # HACK: for the type defined in closure. (e.g. t.NewType)
             py_clsname = typ.__name__
 
         if "." in py_clsname:

--- a/egoist/typing.py
+++ b/egoist/typing.py
@@ -1,0 +1,5 @@
+from metashape.name import NewNamedType, guess_name
+from metashape.name import resolve_maybe as resolve_name_maybe
+from metashape.name import resolve as resolve_name
+
+__all__ = ["NewNamedType", "guess_name", "resolve_name", "resolve_name_maybe"]

--- a/examples/e2e/generate-structkit/09enums/definitions.py
+++ b/examples/e2e/generate-structkit/09enums/definitions.py
@@ -1,13 +1,13 @@
 import typing_extensions as tx
 from egoist.app import App, SettingsDict
+from egoist.typing import NewNamedType
 
 settings: SettingsDict = {"rootdir": "", "here": __file__}
 app = App(settings)
 
 app.include("egoist.directives.define_struct_set")
 
-Op = tx.Literal["add", "sub", "mul"]
-Op.__name__ = "Op"  # TODO: remove
+Op = NewNamedType("Op", tx.Literal["add", "sub", "mul"])
 
 
 @app.define_struct_set("egoist.generators.structkit:walk")

--- a/examples/e2e/generate-structkit/11sum-types/definitions.py
+++ b/examples/e2e/generate-structkit/11sum-types/definitions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import typing as t
 from egoist.app import App, SettingsDict
+from egoist.typing import NewNamedType
 
 settings: SettingsDict = {"rootdir": "", "here": __file__}
 app = App(settings)
@@ -21,8 +22,7 @@ class Node:
     right: t.Optional[Tree]
 
 
-Tree = t.Union[Empty, Leaf, Node]
-Tree.__name__ = "Tree" # todo: remove
+Tree = NewNamedType("Tree", t.Union[Empty, Leaf, Node])
 
 
 @app.define_struct_set("egoist.generators.structkit:walk")


### PR DESCRIPTION
refs #38 

use https://github.com/podhmo/metashape/pull/52

From now on, define named type by `NewNamedType()`

```py
import typing as t
from egoist.types import NewNamedType

class X:
    pass

class Y:
    pass

XorY = NewNamedType("XorY", t.Union[X,Y])
```

## future work

changes to type-checkeble in definitions.py, currently not supported yet.

```py
import typing as tx
from egoist.typing import resolve_name, NewNamedType

Direction = NewNamedType("Direction", tx.Literal["N", "S", "W", "E"])


def use(d: Direction) -> None:
    print("@", d)


print(resolve_name(Direction))
use("N")
use("X")
```

```console
$ mypy --strict --strict-equality --ignore-missing-imports 00resolve.py
00resolve.py:7: error: Variable "00resolve.Direction" is not valid as a type
00resolve.py:7: note: See https://mypy.readthedocs.io/en/latest/common_issues.html#variables-vs-type-aliases
```

